### PR TITLE
IPageStore#getPageは、ページが見つからない時には例外ではなくnullを変えるべき

### DIFF
--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/core/NoSerializePageStore.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/core/NoSerializePageStore.java
@@ -19,13 +19,10 @@ public class NoSerializePageStore implements IPageStore {
     public IManageablePage getPage(String sessionId, int pageId) {
         Map<Integer, IManageablePage> sessionCache =
                 getSessionCache(sessionId, false);
-        IManageablePage page = sessionCache.get(pageId);
-        if (page == null) {
-            throw new IllegalArgumentException(
-                    "Found this session, but there is no page with id "
-                            + pageId);
+        if(sessionCache != null) { 
+            return sessionCache.get(pageId);
         }
-        return page;
+        return null;
     }
 
     public void removePage(String sessionId, int pageId) {
@@ -59,9 +56,6 @@ public class NoSerializePageStore implements IPageStore {
             if (create) {
                 sessionCache = new HashMap<Integer, IManageablePage>();
                 cache.put(sessionId, sessionCache);
-            } else {
-                throw new IllegalArgumentException(
-                        "There are no pages stored for session id " + sessionId);
             }
         }
         return sessionCache;


### PR DESCRIPTION
getPageが例外をスローしてしまうと、エラーページに遷移してしまいます。nullを返せば、Wicketはページ番号0を新たに生成してくれるので、nullを返すべきです。
