### PR TITLE
IE6にて、コンポーネントのリサイズによりWindowのリサイズイベントが複数回発生してしまう問題へ対応

### DIFF
--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGridPanel.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGridPanel.java
@@ -35,12 +35,9 @@ public class FixedGridPanel extends Panel implements IHeaderContributor {
     private static final ResourceReference SCRIPT =
             new JavaScriptResourceReference(FixedGridPanel.class,
                     "karatachi-selectablegrid.js");
-
-    private static final ResourceReference OLD_CSS = new CssResourceReference(
-            FixedGridPanel.class, "old-karatachi-grid.css");
-    private static final ResourceReference OLD_SCRIPT =
+    private static final ResourceReference WRESIZE =
             new JavaScriptResourceReference(FixedGridPanel.class,
-                    "old-karatachi-grid.js");
+                    "jquery-wresize.js");
 
     private final WebMarkupContainer grid_tl;
     private final WebMarkupContainer grid_tr;
@@ -171,31 +168,16 @@ public class FixedGridPanel extends Panel implements IHeaderContributor {
 
     @Override
     public void renderHead(IHeaderResponse response) {
-        WebClientInfo info = (WebClientInfo) getSession().getClientInfo();
-        if (info.getUserAgent().indexOf("MSIE 6.0") != -1) {
-            response.render(CssReferenceHeaderItem.forReference(OLD_CSS));
-            response.render(JavaScriptHeaderItem.forReference(AjaxLibrariesReference.prototype));
-            response.render(JavaScriptHeaderItem.forReference(OLD_SCRIPT));
-            response.render(JavaScriptHeaderItem.forScript(
-                    String.format("var %1$s; var %1$s_pos;", getMarkupId()),
-                    null));
-            response.render(OnDomReadyHeaderItem.forScript(String.format(
-                    "%s = new KaratachiGrid('%s', '%s', '%s', '%s', '%s', %d)",
-                    getMarkupId(), getMarkupId(), grid_br.getMarkupId(),
-                    grid_tl.getMarkupId(), grid_bl.getMarkupId(),
-                    grid_tr.getMarkupId(), alignCol)));
-        } else {
-            response.render(CssReferenceHeaderItem.forReference(CSS));
-            response.render(JavaScriptHeaderItem.forReference(AjaxLibrariesReference.jquery));
-            response.render(JavaScriptHeaderItem.forReference(AjaxLibrariesReference.jquery_textselection));
-            response.render(JavaScriptHeaderItem.forReference(AjaxLibrariesReference.jquery_zclip));
-            response.render(JavaScriptHeaderItem.forReference(FlexComponent.SWFOBJECT_JS));
-            response.render(JavaScriptHeaderItem.forReference(SCRIPT));
-            response.render(OnDomReadyHeaderItem.forScript(String.format(
-                    "jQuery('#%s').fixedgrid({ zclip_swf : '%s', align : %d });",
-                    getMarkupId(),
-                    urlFor(AjaxLibrariesReference.jquery_zclip_swf, null),
-                    alignCol)));
-        }
+        response.render(CssReferenceHeaderItem.forReference(CSS));
+        response.render(JavaScriptHeaderItem.forReference(AjaxLibrariesReference.jquery));
+        response.render(JavaScriptHeaderItem.forReference(AjaxLibrariesReference.jquery_textselection));
+        response.render(JavaScriptHeaderItem.forReference(AjaxLibrariesReference.jquery_zclip));
+        response.render(JavaScriptHeaderItem.forReference(FlexComponent.SWFOBJECT_JS));
+        response.render(JavaScriptHeaderItem.forReference(WRESIZE));
+        response.render(JavaScriptHeaderItem.forReference(SCRIPT));
+        response.render(OnDomReadyHeaderItem.forScript(String.format(
+                "jQuery('#%s').fixedgrid({ zclip_swf : '%s', align : %d });",
+                getMarkupId(),
+                urlFor(AjaxLibrariesReference.jquery_zclip_swf, null), alignCol)));
     }
 }

--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/jquery-wresize.js
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/jquery-wresize.js
@@ -1,0 +1,74 @@
+/*   
+=============================================================================== 
+WResize is the jQuery plugin for fixing the IE window resize bug 
+............................................................................... 
+                                               Copyright 2007 / Andrea Ercolino 
+------------------------------------------------------------------------------- 
+LICENSE: http://www.opensource.org/licenses/mit-license.php 
+WEBSITE: http://noteslog.com/ 
+=============================================================================== 
+*/ 
+ 
+( function( $ )  
+{ 
+    $.fn.wresize = function( f )  
+    { 
+        version = '1.1'; 
+        wresize = {fired: false, width: 0}; 
+ 
+        function resizeOnce()  
+        { 
+            if ( $.browser.msie ) 
+            { 
+                if ( ! wresize.fired ) 
+                { 
+                    wresize.fired = true; 
+                } 
+                else  
+                { 
+                    var version = parseInt( $.browser.version, 10 ); 
+                    wresize.fired = false; 
+                    if ( version < 7 ) 
+                    { 
+                        return false; 
+                    } 
+                    else if ( version == 7 ) 
+                    { 
+                        //a vertical resize is fired once, an horizontal resize twice 
+                        var width = $( window ).width(); 
+                        if ( width != wresize.width ) 
+                        { 
+                            wresize.width = width; 
+                            return false; 
+                        } 
+                    } 
+                } 
+            } 
+ 
+            return true; 
+        } 
+ 
+        function handleWResize( e )  
+        { 
+            if ( resizeOnce() ) 
+            { 
+                return f.apply(this, [e]); 
+            } 
+        } 
+ 
+        this.each( function()  
+        { 
+            if ( this == window ) 
+            { 
+                $( this ).resize( handleWResize ); 
+            } 
+            else 
+            { 
+                $( this ).resize( f ); 
+            } 
+        } ); 
+ 
+        return this; 
+    }; 
+ 
+} ) ( jQuery );

--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/karatachi-selectablegrid.js
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/karatachi-selectablegrid.js
@@ -54,7 +54,7 @@
       bl.height(bottomHeight);
     };
 
-    w.resize(resizeGrid);
+    w.wresize(resizeGrid);
     br.scroll(updateScroll);
 
     resizeGrid();
@@ -358,8 +358,7 @@
       };
     };
 
-    w.resize(reculcRect);
-
+    w.wresize(reculcRect);
     reculcRect();
 
     var scroll = null;
@@ -553,7 +552,7 @@
         alert("選択したセルのコピーには、\nAdobe Flashバージョン9以降のインストールが必要です。");
       };
     }
-
+    
     return this;
   };
 })(jQuery);


### PR DESCRIPTION
jquery-wresizeプラグインを導入し、resizeのかわりにwresizeを呼ぶように変更しました。同時に、IE6のときだけprototype.jsを使うように分岐していたロジックを破棄し、jQueryで統一しました。
