### PR TITLE
グリッド内に左上しかセルがない場合、残りの部分の高さ計算を誤る問題の修正

### DIFF
--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/karatachi-selectablegrid.js
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/karatachi-selectablegrid.js
@@ -52,8 +52,11 @@
     };
 
     var resizeGrid = function() {
-      var rightWidth = self.width() - bl.width();
-      var bottomHeight = self.height() - tr.height();
+      var cellWidth = Math.max(bl.width(), tl.width());
+      var cellHeight = Math.max(tr.height(), tl.height());
+      
+      var rightWidth = self.width() - cellWidth;
+      var bottomHeight = self.height() - cellHeight;
       br.width(rightWidth);
       br.height(bottomHeight);
       tr.width(rightWidth);


### PR DESCRIPTION
グリッドの左上（top_left）しかセルがない場合、元の計算ですと、bl.width()もtr.height()も0になってしまい。グリッド内部が外枠の高さをはみ出してしまいます。

データヘッダがあるのがblとtrだという想定かと思いますが、データがない場合には左上隅もチェックする必要があります。

maxを使って、bl, trがない場合にだけtlも使うようにしました。
