### PR TITLE
FixedGrid内のセル自身が、セルを表すコンポーネントを構築できるようにした

### DIFF
--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGrid.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGrid.java
@@ -245,7 +245,7 @@ public class FixedGrid extends Loop {
             IComponentBuilder builder = (IComponentBuilder) cell;
             return builder.createComponent(id, row, col, cellValue);
         } else {
-            return new Label(id, sb.toString()).setEscapeModelStrings(false);
+            return new Label(id, cellValue).setEscapeModelStrings(false);
         }
     }
 

--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGrid.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGrid.java
@@ -239,7 +239,14 @@ public class FixedGrid extends Loop {
         } else {
             sb.append("N/A");
         }
-        return new Label(id, sb.toString()).setEscapeModelStrings(false);
+        String cellValue = sb.toString();
+        
+        if(cell instanceof IComponentBuilder) {
+            IComponentBuilder builder = (IComponentBuilder) cell;
+            return builder.createComponent(id, row, col, cellValue);
+        } else {
+            return new Label(id, sb.toString()).setEscapeModelStrings(false);
+        }
     }
 
     protected void setCellAttribute(Component component, int row, int col,

--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/IComponentBuilder.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/IComponentBuilder.java
@@ -1,0 +1,18 @@
+package org.karatachi.wicket.grid;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.basic.Label;
+
+
+/**
+ * セルを表すコンポーネントを構築するためのインタフェース。
+ * ICellオブジェクトがこのインタフェースを実装している場合、FixedGridは、コンポーネントの生成をICellオブジェクトに
+ * 委譲します。<br>
+ * ICellがこのインタフェースを実装していない場合は、FixedGridはデフォルトのコンポーネントとして{@link Label}を構築します。
+ * 
+ * @author t_yano
+ * @since 0.5.17
+ */
+public interface IComponentBuilder {
+    Component createComponent(String id, int row, int col, String cellValue);
+}


### PR DESCRIPTION
セルがIComponentBuilderインタフェースを実装している場合は、Labelを作るのではなく、セル自身にコンポーネントの生成を委譲するようにしてみました。
