### PR TITLE
Modelを展開したあとのCellsオブジェクトを匿名クラスが保持しているバグの修正

### DIFF
--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGrid.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/grid/FixedGrid.java
@@ -90,8 +90,6 @@ public class FixedGrid extends Loop {
 
     @Override
     protected void populateItem(LoopItem item) {
-        final Cells cells = model.getObject();
-
         final int adjustedRows = getRows();
         final int adjustedCols = getCols();
 
@@ -132,6 +130,7 @@ public class FixedGrid extends Loop {
                         --coljoined;
                         --rowjoined[adjustedCol - 1];
                     } else {
+                        Cells cells = model.getObject();
                         ICell cell = cells.getCell(row, col);
                         populateCell(item, row, col, cell);
                         if (cell != null && cell.getRowspan() > 1) {


### PR DESCRIPTION
２重のpopulateItemループのうち、外側のループで展開したモデル値(Cellsオブジェクト）を、内側の内部クラス内ループで参照しているため、このモデルオブジェクトは、内側の内部クラスによって保持されます。

もしモデルがLoadableDetachableModelであったとしても、内側の内部クラスがCellsを保持するため、Cellsは開放されません。
