### PR TITLE
古いページキャッシュを消す

### DIFF
--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/core/NoSerializePageManagerProvider.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/core/NoSerializePageManagerProvider.java
@@ -39,6 +39,6 @@ public class NoSerializePageManagerProvider extends DefaultPageManagerProvider {
 
     @Override
     protected IPageStore newPageStore(IDataStore dataStore) {
-        return new NoSerializePageStore();
+        return new NoSerializePageStore(pagesNumber);
     }
 }

--- a/karatachi-wicket/src/main/java/org/karatachi/wicket/core/NoSerializePageStore.java
+++ b/karatachi-wicket/src/main/java/org/karatachi/wicket/core/NoSerializePageStore.java
@@ -2,15 +2,21 @@ package org.karatachi.wicket.core;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.wicket.page.IManageablePage;
 import org.apache.wicket.pageStore.IPageStore;
 
 public class NoSerializePageStore implements IPageStore {
+    final int pageNumbers;
 
     private Map<String, Map<Integer, IManageablePage>> cache =
             new HashMap<String, Map<Integer, IManageablePage>>();
+
+    public NoSerializePageStore(int pageNumbers) {
+        this.pageNumbers = pageNumbers;
+    }
 
     public void destroy() {
         cache = null;
@@ -54,7 +60,14 @@ public class NoSerializePageStore implements IPageStore {
         Map<Integer, IManageablePage> sessionCache = cache.get(sessionId);
         if (sessionCache == null) {
             if (create) {
-                sessionCache = new HashMap<Integer, IManageablePage>();
+                sessionCache = new LinkedHashMap<Integer, IManageablePage>(pageNumbers) {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<Integer, IManageablePage> eldest) {
+                        return size() > pageNumbers;
+                    }
+                };
                 cache.put(sessionId, sessionCache);
             }
         }


### PR DESCRIPTION
NoSerializePageManagerProviderにpagesNumberを指定しても古いキャッシュが残り続けていたので
有効期限を過ぎたキャッシュが消えるようにした。
